### PR TITLE
Fixed the service definition and make sure swift plugins are working

### DIFF
--- a/DependencyInjection/cspooSwiftmailerMailgunExtension.php
+++ b/DependencyInjection/cspooSwiftmailerMailgunExtension.php
@@ -4,6 +4,8 @@ namespace cspoo\Swiftmailer\MailgunBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
@@ -28,6 +30,13 @@ class cspooSwiftmailerMailgunExtension extends Extension
         $container->setParameter('mailgun.key', $config['key']);
         $container->setParameter('mailgun.domain', $config['domain']);
 
+        $definitionDecorator = new DefinitionDecorator('swiftmailer.transport.eventdispatcher.abstract');
+        $container->setDefinition('mailgun.swift_transport.eventdispatcher', $definitionDecorator);
+
+        $container->getDefinition('mailgun.swift_transport.transport')
+            ->replaceArgument(0, new Reference('mailgun.swift_transport.eventdispatcher'));
+
+        //set some alias
         $container->setAlias('mailgun', 'mailgun.swift_transport.transport');
         $container->setAlias('swiftmailer.mailer.transport.mailgun', 'mailgun.swift_transport.transport');
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,13 +6,18 @@
 
     <parameters>
         <parameter key="mailgun.swift_transport.transport.class">cspoo\Swiftmailer\MailgunBundle\Services\MailgunTransport</parameter>
+        <parameter key="mailgun.class">Mailgun\Mailgun</parameter>
     </parameters>
 
     <services>
+        <service id="mailgun.library" class="%mailgun.class%" public="true">
+            <argument>%mailgun.key%</argument>
+        </service>
+
         <service id="mailgun.swift_transport.transport" class="%mailgun.swift_transport.transport.class%" public="true">
-        	<call method="setContainer">
-        		<argument type="service" id="service_container" />
-        	</call>
+            <argument></argument>
+            <argument type="service" id="mailgun.library"></argument>
+            <argument>%mailgun.domain%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
I did some updates here. 
1) Make sure the don't inject the container. That is generally bad practice. We just want to inject the services and the parameters we depend upon. 

2) I'm using the SwithMailer event dispatcher in order to be able to inject plugins. This is used by Symfony with the `delivery_address` parameter for example. 
