### PR TITLE
Support for Mailgun 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,38 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
     - 5.5
     - 5.6
     - 7.0
     - hhvm
 
+env:
+    global:
+        - TEST_COMMAND="phpunit"
+    matrix:
+        - SYMFONY_VERSION=2.8.*
+
+matrix:
+    fast_finish: true
+    include:
+        - php: 5.5
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_VERSION=2.3.* COVERAGE=true TEST_COMMAND="phpunit --coverage-text --coverage-clover=build/coverage.xml"
+        - php: 5.6
+          env: SYMFONY_VERSION=2.3.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.7.*
+        - php: 5.6
+          env: SYMFONY_VERSION=3.0.*
+
 before_install:
-  - composer self-update
+  - travis_retry composer self-update
 
 install:
-  - composer update
+  - composer require symfony/dependency-injection:${SYMFONY_VERSION} --no-update
+  - composer update ${COMPOSER_FLAGS} --prefer-source --no-interaction
 
 script:
-  - phpunit --coverage-clover=coverage.xml
-  
+  - $TEST_COMMAND
+
 after_success:
-  - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then pip install --user codecov && codecov ; fi
+  - if [[ "$COVERAGE" = true ]]; then pip install --user codecov && codecov ; fi

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('mailgun');
+        $rootNode = $treeBuilder->root('cspoo_swiftmailer_mailgun');
 
         $this->addAPIConfigSection($rootNode);
 
@@ -30,11 +30,9 @@ class Configuration implements ConfigurationInterface
     {
         $rootNode
             ->children()
-            ->scalarNode('key')
-                ->isRequired()
-            ->end()
-            ->scalarNode('domain')
-                ->isRequired()
+                ->scalarNode('key')->isRequired()->end()
+                ->scalarNode('domain')->isRequired()->end()
+                ->scalarNode('http_client')->end()
             ->end();
     }
 }

--- a/DependencyInjection/cspooSwiftmailerMailgunExtension.php
+++ b/DependencyInjection/cspooSwiftmailerMailgunExtension.php
@@ -5,8 +5,8 @@ namespace cspoo\Swiftmailer\MailgunBundle\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**
@@ -35,6 +35,10 @@ class cspooSwiftmailerMailgunExtension extends Extension
 
         $container->getDefinition('mailgun.swift_transport.transport')
             ->replaceArgument(0, new Reference('mailgun.swift_transport.eventdispatcher'));
+
+        if (!empty($config['http_client'])) {
+            $container->getDefinition('mailgun.library')->replaceArgument(1, new Reference($config['http_client']));
+        }
 
         //set some alias
         $container->setAlias('mailgun', 'mailgun.swift_transport.transport');

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ http interface for sending messages.
 ## Installation
 
 ```bash
-composer require cspoo/swiftmailer-mailgun-bundle
+composer require cspoo/swiftmailer-mailgun-bundle php-http/guzzle5-adapter
 ```
+
+*Note: You can use any of [these adapters](https://packagist.org/providers/php-http/client-implementation)*
 
 Also add to your AppKernel:
 
@@ -30,6 +32,7 @@ Configure your application with the credentials you find on the [domain overview
 cspoo_swiftmailer_mailgun:
     key: "key-xxxxxxxxxx"
     domain: "mydomain.com"
+    http_client: 'httplug.client' # Optional. Defaults to null and uses dicovery to find client. 
 
 # Swiftmailer Configuration
 swiftmailer:
@@ -64,8 +67,17 @@ Then send it as you normally would with the `mailer` service. Your configuration
 $this->container->get('mailer')->send($message);
 ```
 
-Todo:
- * [x] Add mailgun as a separate transport to the normal Swiftmailer service
- * [ ] Tests
+## Choose HTTP client
+
+Mailgun 2.0 is no longer coupled to Guzzle5. Thanks to [Httplug](http://docs.php-http.org/en/latest/index.html) you can now use any
+library to transport HTTP messages. You can rely on [discovery](http://docs.php-http.org/en/latest/discovery.html) to automatically
+find an installed client or you can use [HttplugBundle](https://github.com/php-http/HttplugBundle) and provide a client service name 
+to the mailgun configuration. 
+
+``` yaml
+// app/config/config.yml:
+cspoo_swiftmailer_mailgun:
+    http_client: 'httplug.client'
+```
 
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,7 +12,7 @@
     <services>
         <service id="mailgun.library" class="%mailgun.class%" public="true">
             <argument>%mailgun.key%</argument>
-            <argument />
+            <argument>null</argument>
         </service>
 
         <service id="mailgun.swift_transport.transport" class="%mailgun.swift_transport.transport.class%" public="true">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,6 +12,7 @@
     <services>
         <service id="mailgun.library" class="%mailgun.class%" public="true">
             <argument>%mailgun.key%</argument>
+            <argument />
         </service>
 
         <service id="mailgun.swift_transport.transport" class="%mailgun.swift_transport.transport.class%" public="true">

--- a/Tests/DependencyInjection/cspooSwiftmailerMailgunExtensionTest.php
+++ b/Tests/DependencyInjection/cspooSwiftmailerMailgunExtensionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace cspoo\Swiftmailer\MailgunBundle\Tests\DependencyInjection;
+
+use cspoo\Swiftmailer\MailgunBundle\DependencyInjection\cspooSwiftmailerMailgunExtension;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class cspooSwiftmailerMailgunExtensionTest extends AbstractExtensionTestCase
+{
+    protected function getContainerExtensions()
+    {
+        return array(
+            new cspooSwiftmailerMailgunExtension()
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getMinimalConfiguration()
+    {
+        return array('key'=>'foo','domain'=>'bar');
+    }
+
+
+    /**
+     * @test
+     */
+    public function after_loading_the_correct_parameter_has_been_set()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('mailgun.key', 'foo');
+        $this->assertContainerBuilderHasParameter('mailgun.domain', 'bar');
+
+        $this->assertContainerBuilderHasAlias('mailgun', 'mailgun.swift_transport.transport');
+        $this->assertContainerBuilderHasAlias('swiftmailer.mailer.transport.mailgun', 'mailgun.swift_transport.transport');
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('mailgun.swift_transport.transport', 0, 'mailgun.swift_transport.eventdispatcher');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('mailgun.library', 1, null);
+    }
+
+    /**
+     * @test
+     */
+    public function after_loading_http_client_is_used()
+    {
+        $this->load(array('http_client'=>'httplug'));
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('mailgun.library', 1, 'httplug');
+    }
+}

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -1,0 +1,12 @@
+# Upgrade
+
+This document will tell you how to upgrade from one version to one other. 
+
+# Upgrade from 0.2.x to 0.3.0
+
+You need to install a HTTP client that provides the virtual package 
+[php-http/client-implementation](https://packagist.org/providers/php-http/client-implementation).
+ Then you need to do one of the following things: 
+ 
+ * Add the client's service name to `cspoo_swiftmailer_mailgun.http_client`. (Preferably with help from [HttplugBundle](https://github.com/php-http/HttplugBundle)
+ * Install `puli/composer-plugin` to let Puli find the installed client automatically.

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,18 @@
     ],
     "minimum-stability" : "stable",
     "require": {
-        "php": ">=5.3",
-        "swiftmailer/swiftmailer" : "~5.0, >=4.0",
-        "mailgun/mailgun-php" : "~1.7"
+        "php": "^5.5|^7.0",
+        "swiftmailer/swiftmailer": "^5.0",
+        "mailgun/mailgun-php": "^2.0",
+        "symfony/dependency-injection": "^2.3|^3.0"
+    },
+    "require-dev": {
+        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
+        "symfony/config": "^2.3|^3.0"
     },
     "suggest": {
-        "azine/mailgunwebhooks-bundle": "Allows to handle Mailgun event webhooks"
+        "azine/mailgunwebhooks-bundle": "Allows to handle Mailgun event webhooks",
+        "php-http/httplug-bundle": "To manage your http clients"
     },
     "autoload": {
         "psr-0": { "cspoo\\Swiftmailer\\MailgunBundle": "" }


### PR DESCRIPTION
This PR include a few changes: 
* Support for Mailgun 2.0. Which means that we are not longer coupled to Guzzle5. 
* Bugfix where our Extension class extends HttpKernel's extension class instead of the extension class in the DependencyInjection component. 
* Tests on different symfony versions
* Tests for our configuration and extension class
* Dropping support for php 5.3 and php 5.4 as a consequence of updating to Mailgun 2.0. 
* Dropping support for Swiftmailer 4.0