### PR TITLE
Corrected the change log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
     - 5.6
     - 7.0
     - 7.1
-    - hhvm
 
 env:
     global:

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ This document will tell you what changes that has been made between versions.
 
 # Changes from 0.3.x to 0.4.0
 
-* Removed `mailgun.library` service and `mailgun.swift_transport.transport.class` parameter.
+* Removed the `mailgun.swift_transport.transport.class` parameter.
 * Improved testing
 * Avoid usage of deprecated Mailgun functions. 
 


### PR DESCRIPTION
The mailgun.library service has not been removed. It is created in the BundleExtension.