### PR TITLE
Update dependencies to support Symfony 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,36 +6,31 @@ cache:
     directories:
         - $HOME/.composer/cache/files
 
-php:
-    - 7.0
-    - 7.1
-
 env:
     global:
         - TEST_COMMAND="composer test"
-    matrix:
-        - SYMFONY_VERSION=3.0.*
 
 matrix:
     fast_finish: true
+    allow_failures:
+        - php: nightly
     include:
         - php: 7.0
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_VERSION=2.7.* COVERAGE=true TEST_COMMAND="composer test-ci"
-        - php: 7.0
-          env: SYMFONY_VERSION=3.0.*
-        - php: 7.0
-          env: SYMFONY_VERSION=3.1.*
-        - php: 7.0
-          env: SYMFONY_VERSION=3.2.*
-        - php: 7.0
-          env: SYMFONY_VERSION=3.3.*
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+        - php: 7.1
+        - php: 7.2
+          env: COVERAGE=true TEST_COMMAND="composer test-ci"
+        - php: 7.2
+          env: DEPENDENCIES=beta
+        - php: nightly
+          env: DEPENDENCIES=beta
 
 before_install:
   - travis_retry composer self-update
+  - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
 
 install:
-  - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
-  - composer update ${COMPOSER_FLAGS} --prefer-source --no-interaction
+  - composer update --prefer-dist --no-progress --no-suggest ${COMPOSER_FLAGS} --no-interaction
 
 script:
   - $TEST_COMMAND

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,17 @@
         "php": ">=7.0.0",
         "swiftmailer/swiftmailer": "^6.0",
         "mailgun/mailgun-php": "^2.3",
-        "symfony/dependency-injection": "^2.7 || ^3.0"
+        "symfony/dependency-injection": "^2.7 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.7",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "nyholm/symfony-bundle-test": "^1.0",
         "symfony/swiftmailer-bundle": "^2.5.1",
-        "symfony/symfony": "^2.7 || ^3.0",
         "php-http/guzzle6-adapter": "^1.0",
-        "guzzlehttp/psr7": "^1.4"
+        "guzzlehttp/psr7": "^1.4",
+        "symfony/framework-bundle": "^2.7 || ^3.0 || ^4.0",
+        "doctrine/annotations": "^1.3"
     },
     "suggest": {
         "azine/mailgunwebhooks-bundle": "Allows to handle Mailgun event webhooks",


### PR DESCRIPTION
Fix #51 

I changed the travis test matrix to avoid running too many tests.

As you can see, it now test:
* php 7.0  with lowest dependencies
* php 7.1
* php 7.2 (with coverage)
* php 7.2 with beta dependencies
* php nightly with beta dependencies (failure allowed)

If you want, I can also create the symfony recipe for this bundle. 