### PR TITLE
Symfony 4 compatibility fix

### DIFF
--- a/DependencyInjection/cspooSwiftmailerMailgunExtension.php
+++ b/DependencyInjection/cspooSwiftmailerMailgunExtension.php
@@ -4,10 +4,10 @@ namespace cspoo\Swiftmailer\MailgunBundle\DependencyInjection;
 
 use Mailgun\HttpClientConfigurator;
 use Mailgun\Mailgun;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader;
@@ -33,7 +33,7 @@ class cspooSwiftmailerMailgunExtension extends Extension
         $container->setParameter('mailgun.key', $config['key']);
         $container->setParameter('mailgun.domain', $config['domain']);
 
-        $definitionDecorator = new DefinitionDecorator('swiftmailer.transport.eventdispatcher.abstract');
+        $definitionDecorator = new ChildDefinition('swiftmailer.transport.eventdispatcher.abstract');
         $container->setDefinition('mailgun.swift_transport.eventdispatcher', $definitionDecorator);
 
         $container->getDefinition('mailgun.swift_transport.transport')

--- a/Tests/Service/MailgunTransportTest.php
+++ b/Tests/Service/MailgunTransportTest.php
@@ -6,8 +6,9 @@ use Mailgun\Connection\Exceptions\MissingEndpoint;
 use cspoo\Swiftmailer\MailgunBundle\Service\MailgunTransport;
 use Mailgun\Exception\UnknownErrorException;
 use Mailgun\Model\Message\SendResponse;
+use PHPUnit\Framework\TestCase;
 
-class MailgunTransportTest extends \PHPUnit_Framework_TestCase
+class MailgunTransportTest extends TestCase
 {
     public function testGetPostData()
     {
@@ -159,7 +160,7 @@ class MailgunTransportTest extends \PHPUnit_Framework_TestCase
         $dispatcher->expects($this->any())
             ->method('createSendEvent')
             ->willReturn($this->getMockBuilder('Swift_Events_SendEvent')->disableOriginalConstructor()->getMock());
-            
+
 
         $messageApi = $this->getMockBuilder('Mailgun\Api\Message')
             ->disableOriginalConstructor()

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,16 @@
         "php": "^7.0",
         "swiftmailer/swiftmailer": "^6.0",
         "mailgun/mailgun-php": "^2.3",
-        "symfony/dependency-injection": "^2.7 || ^3.0 || ^4.0"
+        "symfony/dependency-injection": "^3.3 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",
-        "matthiasnoback/symfony-dependency-injection-test": "^1.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^2.3",
         "nyholm/symfony-bundle-test": "^1.0",
         "symfony/swiftmailer-bundle": "^2.5.1",
         "php-http/guzzle6-adapter": "^1.0",
         "guzzlehttp/psr7": "^1.4",
-        "symfony/framework-bundle": "^2.7 || ^3.0 || ^4.0",
+        "symfony/framework-bundle": "^3.3 || ^4.0",
         "doctrine/annotations": "^1.3"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
         "symfony/dependency-injection": "^3.3 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^2.3",
-        "nyholm/symfony-bundle-test": "^1.0",
+        "nyholm/symfony-bundle-test": "^1.4",
         "symfony/swiftmailer-bundle": "^2.5.1",
         "php-http/guzzle6-adapter": "^1.0",
         "guzzlehttp/psr7": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/dependency-injection": "^2.7 || ^3.0 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.7",
+        "phpunit/phpunit": "^5.7",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "nyholm/symfony-bundle-test": "^1.0",
         "symfony/swiftmailer-bundle": "^2.5.1",


### PR DESCRIPTION
DefinitionDecorator got deprecated in symfony 3.3 and removed in symfony 4.
It got replaced by ```Symfony\Component\DependencyInjection\ChildDefinition```.

See http://api.symfony.com/3.4/Symfony/Component/DependencyInjection/DefinitionDecorator.html