### PR TITLE
adding exception logging

### DIFF
--- a/Service/MailgunTransport.php
+++ b/Service/MailgunTransport.php
@@ -112,6 +112,14 @@ class MailgunTransport implements Swift_Transport
             $failedRecipients = $postData['to'];
             $sent = 0;
             $resultStatus = Swift_Events_SendEvent::RESULT_FAILED;
+
+            $errorMessage = $e->getCode() . ' : ' . $e->getMessage();
+            if ($failEvt = $this->eventDispatcher->createResponseEvent($this, $errorMessage, false)) {
+                $this->eventDispatcher->dispatchEvent($failEvt, 'responseReceived');
+                if ($failEvt->bubbleCancelled()) {
+                    return 0;
+                }
+            }
         }
 
         if ($evt) {


### PR DESCRIPTION
This taps into the `responseReceived` event and it logs code + message (`401: Cannot send message without a recipient`). #34 

I'm using this outside of Symfony so my manual test looks like this:
```
$domain = 'test.com';
// Use incorrect key to verify the error is logged
$apiKey = 'API_KEY';

$eventDispatch = new \Swift_Events_SimpleEventDispatcher();
$mailgun = \Mailgun\Mailgun::create($apiKey);
$transport = new \cspoo\Swiftmailer\MailgunBundle\Service\MailgunTransport($eventDispatch, $mailgun, $domain);
$mailer = Swift_Mailer::newInstance($transport);

$swiftReporter = new Swift_Plugins_Reporters_HitReporter();
$mailer->registerPlugin(new Swift_Plugins_ReporterPlugin($swiftReporter));

$swiftLogger = new Swift_Plugins_Loggers_ArrayLogger();
$mailer->registerPlugin(new Swift_Plugins_LoggerPlugin($swiftLogger));

$message = Swift_Message::newInstance();
$message->setTo('foo@foo.com')
    ->setFrom('bar@bar.com')
    ->setSubject('Foo bar')
    ->setBody('test message');

$result = $mailer->send($message);

pr($swiftLogger->dump());
```