### PR TITLE
Added configuration for endpoint - EU region has different endpoint URL

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('key')->isRequired()->end()
                 ->scalarNode('domain')->isRequired()->end()
+                ->scalarNode('endpoint')->end()
                 ->scalarNode('http_client')->end()
             ->end();
     }

--- a/DependencyInjection/cspooSwiftmailerMailgunExtension.php
+++ b/DependencyInjection/cspooSwiftmailerMailgunExtension.php
@@ -54,6 +54,9 @@ class cspooSwiftmailerMailgunExtension extends Extension
     {
         $configuratorDef = new Definition(HttpClientConfigurator::class);
         $configuratorDef->addMethodCall('setApiKey', [$config['key']]);
+        if (!empty($config['endpoint'])) {
+            $configuratorDef->addMethodCall('setEndpoint', [$config['endpoint']]);
+        }
 
         if (!empty($config['http_client'])) {
             $configuratorDef->addMethodCall('setHttpClient', [new Reference($config['http_client'])]);

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Configure your application with the credentials you find on the [domain overview
 cspoo_swiftmailer_mailgun:
     key: "key-xxxxxxxxxx"
     domain: "mydomain.com"
-    http_client: 'httplug.client' # Optional. Defaults to null and uses discovery to find client. 
+    endpoint: "https://api.eu.mailgun.net" # Optional. Use this config for EU region. Defaults to "https://api.mailgun.net"
+    http_client: "httplug.client" # Optional. Defaults to null and uses discovery to find client. 
 
 # Swiftmailer Configuration
 swiftmailer:

--- a/Tests/DependencyInjection/cspooSwiftmailerMailgunExtensionTest.php
+++ b/Tests/DependencyInjection/cspooSwiftmailerMailgunExtensionTest.php
@@ -4,6 +4,7 @@ namespace cspoo\Swiftmailer\MailgunBundle\Tests\DependencyInjection;
 
 use cspoo\Swiftmailer\MailgunBundle\DependencyInjection\cspooSwiftmailerMailgunExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -22,7 +23,7 @@ class cspooSwiftmailerMailgunExtensionTest extends AbstractExtensionTestCase
      */
     protected function getMinimalConfiguration()
     {
-        return array('key'=>'foo','domain'=>'bar');
+        return array('key' => 'foo', 'domain' => 'bar', 'endpoint' => 'baz');
     }
 
 
@@ -35,6 +36,18 @@ class cspooSwiftmailerMailgunExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasParameter('mailgun.key', 'foo');
         $this->assertContainerBuilderHasParameter('mailgun.domain', 'bar');
+
+        /** @var Definition $definition */
+        $definition = $this->container->getDefinition('mailgun.library')->getArgument(0);
+        foreach ($definition->getMethodCalls() as $methodCall) {
+            if ($methodCall[0] !== 'setEndpoint') {
+                continue;
+            }
+
+            $setEndpointArguments = $methodCall[1];
+            $this->assertEquals('baz', $setEndpointArguments[0]);
+            break;
+        }
 
         $this->assertContainerBuilderHasAlias('mailgun', 'mailgun.swift_transport.transport');
         $this->assertContainerBuilderHasAlias('swiftmailer.mailer.transport.mailgun', 'mailgun.swift_transport.transport');


### PR DESCRIPTION
EU Region has different endpoint URL for API: `https://api.eu.mailgun.net`
https://help.mailgun.com/hc/en-us/articles/360007512013-Can-I-migrate-my-domain-to-EU- (Configuration Changes section)