### PR TITLE
Logging errors

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,10 +5,12 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/ schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="mailgun.logger" class="Psr\Log\NullLogger" />
         <service id="mailgun.swift_transport.transport" class="cspoo\Swiftmailer\MailgunBundle\Service\MailgunTransport" public="true">
-            <argument></argument>
-            <argument type="service" id="mailgun.library"></argument>
+            <argument />
+            <argument type="service" id="mailgun.library" />
             <argument>%mailgun.domain%</argument>
+            <argument type="service" id="mailgun.logger" />
         </service>
     </services>
 </container>

--- a/Service/MailgunTransport.php
+++ b/Service/MailgunTransport.php
@@ -4,7 +4,6 @@ namespace cspoo\Swiftmailer\MailgunBundle\Service;
 
 use Mailgun\Exception\HttpClientException;
 use Mailgun\Mailgun;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Swift_Events_EventListener;
 use Swift_Events_SendEvent;

--- a/Service/MailgunTransport.php
+++ b/Service/MailgunTransport.php
@@ -121,23 +121,7 @@ class MailgunTransport implements Swift_Transport
         try {
             $response = $this->mailgun->messages()->sendMime($domain, $postData['to'], $message->toString(), $postData);
             if ($response instanceof ResponseInterface) {
-                // Log response in case of api error
-                $statusCode = $response->getStatusCode();
-                $context = [
-                    'mailgun_http_response_code' => $statusCode,
-                    'mailgun_http_response_reason_phrase' => $response->getReasonPhrase()
-                ];
-
-                if ($statusCode > 399 && $statusCode < 500) {
-                    $this->logger->warning(
-                        "Mailgun API is telling us we're doing something wrong",
-                        $context
-                    );
-                    throw new \Exception();
-                } elseif ($statusCode > 499 && $statusCode < 600) {
-                    $this->logger->error("Mailgun API produced an error", $context);
-                    throw new \Exception();
-                }
+                // TODO: log response in case of api error
             }
             $resultStatus = Swift_Events_SendEvent::RESULT_SUCCESS;
         } catch (\Exception $e) {

--- a/Tests/Service/MailgunTransportTest.php
+++ b/Tests/Service/MailgunTransportTest.php
@@ -122,7 +122,8 @@ class MailgunTransportTest extends TestCase
     {
         $dispatcher = $this->getMockBuilder('Swift_Events_EventDispatcher')->getMock();
         $mailgun = $this->getMockBuilder('Mailgun\Mailgun')->getMock();
-        $transport = new MailgunTransport($dispatcher, $mailgun, 'default.com');
+        $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+        $transport = new MailgunTransport($dispatcher, $mailgun, 'default.com', $logger);
 
         $messageApi = $this->getMockBuilder('Mailgun\Api\Message')
             ->disableOriginalConstructor()
@@ -177,6 +178,9 @@ class MailgunTransportTest extends TestCase
             ->method('messages')
             ->willReturn($messageApi);
 
-        return new MailgunTransport($dispatcher, $mailgun, 'default.com');
+        $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')
+            ->getMock();
+
+        return new MailgunTransport($dispatcher, $mailgun, 'default.com', $logger);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "mailgun/mailgun-php": "^2.3",
         "symfony/config": "^3.3 || ^4.0",
         "symfony/dependency-injection": "^3.3 || ^4.0",
-        "symfony/http-kernel": "^3.3 || ^4.0"
+        "symfony/http-kernel": "^3.3 || ^4.0",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,4 +26,8 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\CoverageListener"/>
+    </listeners>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
         >
 
     <testsuites>
-        <testsuite>
+        <testsuite name="All Tests">
             <directory>./Tests</directory>
         </testsuite>
     </testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,12 +8,9 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
-         codecoverage="true"
          bootstrap="./vendor/autoload.php"
         >
 
-    <formatter type="clover" usefile="false"/>
     <testsuites>
         <testsuite>
             <directory>./Tests</directory>


### PR DESCRIPTION
In the current version it seems that errors coming from the API are handled without exposing them in any way. Presumably the reason for this is that SwiftMailer does not facilitate in a way to provide the reason of failure.

For devs/admins this poses a problem as it becomes quite difficult to figure out what exactly went wrong. Things silently failing and "hiding" the actual error does not seem to be helping in that case.

Hence this PR of my suggestion to log the errors.

By default the NullLogger is used, so there is the option of enabling or disabling this logging feature, by means of service definitions.