### PR TITLE
mailgun/mailgun-php ^3.0

### DIFF
--- a/DependencyInjection/cspooSwiftmailerMailgunExtension.php
+++ b/DependencyInjection/cspooSwiftmailerMailgunExtension.php
@@ -2,7 +2,7 @@
 
 namespace cspoo\Swiftmailer\MailgunBundle\DependencyInjection;
 
-use Mailgun\HttpClientConfigurator;
+use Mailgun\HttpClient\HttpClientConfigurator;
 use Mailgun\Mailgun;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.0",
         "swiftmailer/swiftmailer": "^6.0",
-        "mailgun/mailgun-php": "^2.3",
+        "mailgun/mailgun-php": "^3.0",
         "symfony/config": "^3.3 || ^4.0",
         "symfony/dependency-injection": "^3.3 || ^4.0",
         "symfony/http-kernel": "^3.3 || ^4.0",


### PR DESCRIPTION
This PR updates the `mailgun/mailgun-php` package to `^3.0`, which fixes dependency conflicts with Symfony 4.2+ (#78, #79), as well as php-http/guzzle7-adapter.