### PR TITLE
Add support for mailgun-php ^3.0

### DIFF
--- a/DependencyInjection/cspooSwiftmailerMailgunExtension.php
+++ b/DependencyInjection/cspooSwiftmailerMailgunExtension.php
@@ -2,7 +2,7 @@
 
 namespace cspoo\Swiftmailer\MailgunBundle\DependencyInjection;
 
-use Mailgun\HttpClientConfigurator;
+use Mailgun\HttpClient\HttpClientConfigurator;
 use Mailgun\Mailgun;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -63,8 +63,7 @@ class cspooSwiftmailerMailgunExtension extends Extension
         }
 
         $mailgunDef = new Definition(Mailgun::class);
-        $mailgunDef->setFactory([Mailgun::class, 'configure'])
-            ->addArgument($configuratorDef);
+        $mailgunDef->addArgument($configuratorDef);
 
         $container->setDefinition('mailgun.library', $mailgunDef);
     }

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ http interface for sending messages.
 ## Installation
 
 ```bash
-composer require cspoo/swiftmailer-mailgun-bundle php-http/guzzle5-adapter
+composer require cspoo/swiftmailer-mailgun-bundle kriswallsmith/buzz nyholm/psr7
 ```
 
-*Note: You can use any of [these adapters](https://packagist.org/providers/php-http/client-implementation)*
+*Note: `kriswallsmith/buzz` and `nyholm/psr7` are suggestions, you have the flexibility to choose what [PSR-7 implementation and HTTP client](https://packagist.org/providers/php-http/client-implementation) you want to use.*
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,6 @@ Configure your Mailgun credentials:
 cspoo_swiftmailer_mailgun:
     key: '%env(MAILGUN_API_KEY)%'
     domain: "%env(MAILGUN_DOMAIN)%"
-
-services:
-    Mailgun\Mailgun:
-        class: Mailgun\Mailgun
-        factory: ['Mailgun\Mailgun', create]
-        arguments: ['%env(MAILGUN_API_KEY)%']
 ```
 
 Finally, add the following line on swiftmailer config:
@@ -124,7 +118,7 @@ bin/console swiftmailer:email:send --from=<from email> --to=<to email> --subject
 
 ## Choose HTTP client
 
-Mailgun 2.0 is no longer coupled to Guzzle5. Thanks to [Httplug](http://docs.php-http.org/en/latest/index.html) you can now use any
+Starting from version 2.0, the Mailgun library is no longer coupled to Guzzle5. Thanks to [Httplug](http://docs.php-http.org/en/latest/index.html) you can now use any
 library to transport HTTP messages. You can rely on [discovery](http://docs.php-http.org/en/latest/discovery.html) to automatically
 find an installed client or you can use [HttplugBundle](https://github.com/php-http/HttplugBundle) and provide a client service name 
 to the mailgun configuration. 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.0",
         "swiftmailer/swiftmailer": "^6.0",
-        "mailgun/mailgun-php": "^2.3",
+        "mailgun/mailgun-php": "^3.0",
         "symfony/config": "^3.3 || ^4.0",
         "symfony/dependency-injection": "^3.3 || ^4.0",
         "symfony/http-kernel": "^3.3 || ^4.0",


### PR DESCRIPTION
This PR updates the mailgun/mailgun-php package to ^3.0, which fixes dependency conflicts with Symfony 4.2+ (#78, #79), as well as php-http/guzzle7-adapter. It continues work on #84.